### PR TITLE
supports browsing through a presentation on the phone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .*.swp
+node_modules/
+.lsp/
+.clj-kondo/

--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
 body { 
   margin: 0;
   min-height: 100vh;
+  min-width: 100vb;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8,14 +9,29 @@ body {
   font-size: 2em;
 }
 
+#dec, #inc {
+  cursor: pointer;
+  font-size: 1.5em;
+}
+
 @media (width <= 1024px) {
   body {
     font-size: 1.5em;
+  }
+  #dec, #inc {
+    font-size: 1.2em;
   }
 }
 
 @media (width <= 600px) {
   body {
+    font-size: 1em;
+  }
+  section {
+    margin: 0 2rem;
+  }
+
+  #dec, #inc {
     font-size: 1em;
   }
 }
@@ -42,4 +58,25 @@ footer {
   position: fixed;
   bottom: 0;
   padding: 1em 0;
+}
+
+
+#inc {
+  border: 1px solid black;
+  padding: 1rem;
+  border-radius: 10%;
+  position: absolute;
+  top: 35vh;
+  right: 0;
+  margin: 1rem;
+}
+
+#dec {
+  border: 1px solid black;
+  padding: 1rem;
+  border-radius: 10%;
+  position: absolute;
+  top: 35vh;
+  left: 0;
+  margin: 1rem;
 }


### PR DESCRIPTION
## What was changed and why

- [x] adds entries to .gitignore

When setting up the project as the readme states, one will eventually end up with `node_modules`, `.lsp` and `.clj-kondo` directory.

- [x] adds style to support tap event helper carets 

I styled the carets as boxes, to make them stand out and provide a bigger area to interact with.

- [x] implements the caret tap component

Where the magic happens. Carets disappear after an interaction, be it a keydown or tap.

---

Please feel free to change to your desire and thank you for the opportunity to chip in 🤗 

### Screenshot

![image](https://github.com/user-attachments/assets/4164e95d-9269-4202-8a02-0bb534f775ac)

### Issue

closes #1 